### PR TITLE
Potential fix for #6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy
 pandas
 pmagpy
 matplotlib
+scipy


### PR DESCRIPTION
As suggested in #6, adding `scipy` to `requirements.txt file`. Since my local build in which the autodoc _did_ work was in an environment which _did_ have `scipy`, I think that suggestion was correct.